### PR TITLE
Improve performance of the convert method

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,22 +7,21 @@ var specifications = [ require('./specifications/volume.json')
 
 function initSpecificationsHashMap() {
   var hashMap = {
-    fromSymbol: {},
-    fromName: {}
+      fromSymbol: {}
+    , fromName: {}
   };
 
   specifications.forEach(function (specification, specificationId) {
     specification.values.forEach(function (value, valueId) {
       hashMap.fromName[value.name] = hashMap.fromSymbol[value.symbol] = {
-        specificationId: specificationId,
-        valueId: valueId
+          specificationId: specificationId
+        , valueId: valueId
       };
     });
   });
 
   return hashMap;
 }
-
 
 function Unitor(value, unit) {
   this.value = value;
@@ -39,8 +38,8 @@ function Unitor(value, unit) {
 }
 
 Unitor.prototype.convert = function (symbol) {
-  var coef = this.unit.coef,
-      unit = specificationsHashMap.fromSymbol[symbol] || specificationsHashMap.fromName[symbol];
+  var coef = this.unit.coef
+    , unit = specificationsHashMap.fromSymbol[symbol] || specificationsHashMap.fromName[symbol];
 
   if (!unit) {
     throw new Error('Cannot convert ' + this.name + ' units to ' + symbol + ' units.');
@@ -59,4 +58,3 @@ var unitor = function (value, unit) {
 };
 
 module.exports = unitor;
-

--- a/index.js
+++ b/index.js
@@ -1,46 +1,53 @@
 'use strict';
 
-var _ = require('lodash')
-  , specifications = [ require('./specifications/volume.json')
-    , require('./specifications/mass.json')
-    , require('./specifications/energy.json') ];
+var specifications = [ require('./specifications/volume.json')
+  , require('./specifications/mass.json')
+  , require('./specifications/energy.json') ]
+  , specificationsHashMap = initSpecificationsHashMap();
+
+function initSpecificationsHashMap() {
+  var hashMap = {
+    fromSymbol: {},
+    fromName: {}
+  };
+
+  specifications.forEach(function (specification, specificationId) {
+    specification.values.forEach(function (value, valueId) {
+      hashMap.fromName[value.name] = hashMap.fromSymbol[value.symbol] = {
+        specificationId: specificationId,
+        valueId: valueId
+      };
+    });
+  });
+
+  return hashMap;
+}
+
 
 function Unitor(value, unit) {
   this.value = value;
-  if (typeof unit === 'object') {
-    this.unit = unit;
-  } else {
-    for (var i = 0; i < specifications.length; i++) {
-      var foundUnit = _.findKey(specifications[ i ].values
-          , { 'symbol': unit }) || _.findKey(specifications[ i ].values, { 'name': unit });
-      if (foundUnit) {
-        this.system = specifications[ i ];
-        this.name = this.system.name;
-        this.unit = specifications[ i ].values[ foundUnit ];
-        break;
-      }
-    }
-  }
-  if (!this.system) {
+
+  var unitIds = specificationsHashMap.fromSymbol[unit];
+
+  if (!unit) {
     throw new Error('The unit ' + unit + ' does not exists.');
   }
+
+  this.system = specifications[unitIds.specificationId]
+  this.name = this.system.name;
+  this.unit = this.system.values[unitIds.valueId];
 }
 
 Unitor.prototype.convert = function (symbol) {
-  var coef = this.unit.coef;
-  for (var i = 0; i < specifications.length; i++) {
-    var unit = _.findKey(specifications[ i ].values, { 'symbol': symbol });
-    if (unit) {
-      if (specifications[ i ].name !== this.name) {
-        throw new Error('Cannot convert ' + this.name + ' units in ' + specifications[ i ].name + ' units.');
-      } else {
-        this.unit = specifications[ i ].values[ unit ];
-        this.symbol = unit.symbol;
-        this.value /= coef / this.unit.coef;
-      }
-      break;
-    }
+  var coef = this.unit.coef,
+      unit = specificationsHashMap.fromSymbol[symbol] || specificationsHashMap.fromName[symbol];
+
+  if (!unit) {
+    throw new Error('Cannot convert ' + this.name + ' units to ' + symbol + ' units.');
   }
+  this.unit = this.system.values[unit.valueId];
+  this.symbol = this.unit.symbol;
+  this.value /= coef / this.unit.coef;
 };
 
 Unitor.prototype.toString = function () {
@@ -52,3 +59,4 @@ var unitor = function (value, unit) {
 };
 
 module.exports = unitor;
+

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "description": "A lightweight module to manipulate all the units you want.",
   "version": "0.1.2",
   "dependencies": {
-    "lodash": "^2.4.1"
   },
   "scripts": {
     "lint": "jshint .",


### PR DESCRIPTION
In order to fix #1
To improve performance of this module, I pre-generate a matching table between symbols and unit data. Doing it this way, no loops are needed in the `convert` method (and also in the constructor)

Performance improvements are really interesting:
http://jsperf.com/uniter

I also remove the type checking in the constructor because initializing `Unitor` with an object from an unknown specification has no meaning (I think). We can discuss about it, I maybe misunderstood this part

Unitor don't need `lodash` anymore.